### PR TITLE
Fixed errors using `super-error` so error.stack works.

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -8,14 +8,14 @@ var SuperError = require('super-error');
 
 //----------------------------------------------------------------------------------------------------------------------
 
-var NotImplementedError = SuperError.subclass('NotImplementedError', function(api)
+SuperError.subclass(exports, 'NotImplementedError', function(api)
 {
     this.message = api + " not implemented.";
 }); // end NotImplementedError
 
 //----------------------------------------------------------------------------------------------------------------------
 
-var DocumentNotFound = SuperError.subclass('DocumentNotFound', function(id)
+SuperError.subclass(exports, 'DocumentNotFound', function(id)
 {
     this.id = id;
     this.message = "Document with id '" + id + "' not found.";
@@ -23,19 +23,11 @@ var DocumentNotFound = SuperError.subclass('DocumentNotFound', function(id)
 
 //----------------------------------------------------------------------------------------------------------------------
 
-var ValidationError = SuperError.subclass('ValidationError', function(key, expectedType, message)
+SuperError.subclass(exports, 'ValidationError', function(key, expectedType, message)
 {
     this.key = key;
     this.expectedType = expectedType;
     this.message = message || "Key '" + key + "' is not of type '" + expectedType +"'.";
 }); // end ValidationError
-
-//----------------------------------------------------------------------------------------------------------------------
-
-module.exports = {
-    NotImplementedError: NotImplementedError,
-    DocumentNotFound: DocumentNotFound,
-    ValidationError: ValidationError
-}; // end exports
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -4,46 +4,31 @@
 // @module error.js
 //----------------------------------------------------------------------------------------------------------------------
 
-var util = require('util');
+var SuperError = require('super-error');
 
 //----------------------------------------------------------------------------------------------------------------------
 
-function NotImplementedError(api)
+var NotImplementedError = SuperError.subclass('NotImplementedError', function(api)
 {
-    Error.call(this);
-
-    this.name = "NotImplementedError";
     this.message = api + " not implemented.";
-} // end NotImplementedError
-
-util.inherits(NotImplementedError, Error);
+}); // end NotImplementedError
 
 //----------------------------------------------------------------------------------------------------------------------
 
-function DocumentNotFound(id)
+var DocumentNotFound = SuperError.subclass('DocumentNotFound', function(id)
 {
-    Error.call(this);
-
-    this.name = "DocumentNotFound";
     this.id = id;
     this.message = "Document with id '" + id + "' not found.";
-} // end DocumentNotFound
-
-util.inherits(DocumentNotFound, Error);
+}); // end DocumentNotFound
 
 //----------------------------------------------------------------------------------------------------------------------
 
-function ValidationError(key, expectedType, message)
+var ValidationError = SuperError.subclass('ValidationError', function(key, expectedType, message)
 {
-    Error.call(this);
-
-    this.name = "ValidationError";
     this.key = key;
     this.expectedType = expectedType;
     this.message = message || "Key '" + key + "' is not of type '" + expectedType +"'.";
-} // end ValidationError
-
-util.inherits(ValidationError, Error);
+}); // end ValidationError
 
 //----------------------------------------------------------------------------------------------------------------------
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "bluebird": "^2.3.11",
     "lodash": "~2.4.1",
     "node-uuid": "^1.4.1",
-    "oftype": "^0.1.2"
+    "oftype": "^0.1.2",
+    "super-error": "^1.1.0"
   },
   "devDependencies": {
     "mocha": "~1.18.2"


### PR DESCRIPTION
For bonus points, this also simplifies the custom error class code, by removing the previous boilerplate lines.

----

`error.stack` before:
```javascript
Possibly unhandled ValidationError: Key 'name' is not of type 'function String() { [native code] }'.
```

`error.stack` after:
```javascript
Possibly unhandled ValidationError: Key 'name' is not of type 'function String() { [native code] }'.
    at fail (/home/whitelynx/devel/skewedaspect/jbase/lib/models.js:167:20)
    at /home/whitelynx/devel/skewedaspect/jbase/lib/models.js:192:28
    at Function.forIn (/home/whitelynx/devel/skewedaspect/jbase/node_modules/lodash/dist/lodash.js:2023:15)
    at /home/whitelynx/devel/skewedaspect/jbase/lib/models.js:170:11
    at tryCatcher (/home/whitelynx/devel/skewedaspect/jbase/node_modules/bluebird/js/main/util.js:24:31)
    at Promise._resolveFromResolver (/home/whitelynx/devel/skewedaspect/jbase/node_modules/bluebird/js/main/promise.js:448:31)
    at new Promise (/home/whitelynx/devel/skewedaspect/jbase/node_modules/bluebird/js/main/promise.js:55:37)
    at JDBModel.Model.validate (/home/whitelynx/devel/skewedaspect/jbase/lib/models.js:163:12)
    at JDBModel.Model.save (/home/whitelynx/devel/skewedaspect/jbase/lib/models.js:106:32)
    at Context.<anonymous> (/home/whitelynx/devel/skewedaspect/jbase/tests/models.spec.js:74:18)
    at Test.Runnable.run (/home/whitelynx/devel/skewedaspect/jbase/node_modules/mocha/lib/runnable.js:196:15)
    at Runner.runTest (/home/whitelynx/devel/skewedaspect/jbase/node_modules/mocha/lib/runner.js:374:10)
    at /home/whitelynx/devel/skewedaspect/jbase/node_modules/mocha/lib/runner.js:452:12
    at next (/home/whitelynx/devel/skewedaspect/jbase/node_modules/mocha/lib/runner.js:299:14)
    at /home/whitelynx/devel/skewedaspect/jbase/node_modules/mocha/lib/runner.js:309:7
    at next (/home/whitelynx/devel/skewedaspect/jbase/node_modules/mocha/lib/runner.js:247:23)
    at Object._onImmediate (/home/whitelynx/devel/skewedaspect/jbase/node_modules/mocha/lib/runner.js:276:5)
    at processImmediate [as _immediateCallback] (timers.js:354:15)
```