### PR TITLE
Create `rootPath` if it doesn't exist

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -31,3 +31,10 @@ SuperError.subclass(exports, 'ValidationError', function(key, expectedType, mess
 }); // end ValidationError
 
 //----------------------------------------------------------------------------------------------------------------------
+
+SuperError.subclass(exports, 'WriteError', function(message)
+{
+    this.message = "Error writing database: " + message;
+}); // end WriteError
+
+//----------------------------------------------------------------------------------------------------------------------

--- a/lib/jdb.js
+++ b/lib/jdb.js
@@ -14,6 +14,9 @@ var uuid = require('node-uuid');
 var Promise = require('bluebird');
 
 var fs = Promise.promisifyAll(require('fs'));
+var mkdirp = Promise.promisify(require('mkdirp'));
+
+var errors = require('./errors');
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -121,6 +124,21 @@ JDB.prototype._writeToDisk = function()
         return Promise.delay(timeout)
             .then(function()
             {
+                return fs.statAsync(self.rootPath);
+            })
+            .then(function(stats)
+            {
+                if(!stats.isDirectory())
+                {
+                    throw new errors.WriteError("Root path " + JSON.stringify(self.rootPath) + " is not a directory!");
+                } // end if
+            })
+            .catch(function(error) { return error.code == 'ENOENT'; }, function()
+            {
+                return mkdirp(self.rootPath);
+            })
+            .then(function()
+            {
                 self._dirty = false;
 
                 // If we're set to pretty print, we use a 4 space indent, otherwise, undefined.
@@ -141,6 +159,11 @@ JDB.prototype._writeToDisk = function()
                 {
                     return self._writeToDisk();
                 } // end if
+            })
+            .catch(function(error) { return !(error instanceof errors.WriteError); }, function(error)
+            {
+                // Wrap any errors in a WriteError so the message says that writing the DB failed.
+                throw new errors.WriteError(error.message).causedBy(error);
             });
     }
     else

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "bluebird": "^2.3.11",
     "lodash": "~2.4.1",
+    "mkdirp": "^0.5.0",
     "node-uuid": "^1.4.1",
     "oftype": "^0.1.2",
     "super-error": "^1.1.0"


### PR DESCRIPTION
Also adds `WriteError` class for wrapping errors while writing the DB so we get useful error messages. (starting with "Error writing database:")

Fixes #12.